### PR TITLE
Updates for clarity and PE 2015 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,6 @@ Classify your PuppetDB nodes with `puppetdb_shared_cert::puppetdb`, and the stan
 ```
 class { 'puppetdb_shared_cert::puppetdb':
   certname      => 'puppetdb-shared-cert',
-  dns_alt_names => ['puppetdb.bar.com','puppetdb'],
 }
 ```
 

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -20,7 +20,7 @@ class puppetdb_shared_cert::puppetdb (
     owner   => $key_owner,
     group   => $key_group,
   }
-  file { 'puppetdb-shared-publickey':
+  file { 'puppetdb-shared-privatekey':
     ensure  => file,
     content => file("/etc/puppetlabs/puppet/ssl/private_keys/${certname}.pem"),
     path    => "/etc/puppetlabs/puppet/ssl/private_keys/${certname}.pem",
@@ -28,7 +28,7 @@ class puppetdb_shared_cert::puppetdb (
     owner   => $key_owner,
     group   => $key_group,
   }
-  file { 'puppetdb-shared-privatekey':
+  file { 'puppetdb-shared-publickey':
     ensure  => file,
     content => file("/etc/puppetlabs/puppet/ssl/public_keys/${certname}.pem"),
     path    => "/etc/puppetlabs/puppet/ssl/public_keys/${certname}.pem",

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -1,10 +1,8 @@
 class puppetdb_shared_cert::puppetdb (
   $certname = $puppetdb_shared_cert::certname,
-  $dns_alt_names = $puppetdb_shared_cert::dns_alt_names
 ) inherits puppetdb_shared_cert {
 
   validate_string($certname)
-  validate_array($dns_alt_names)
 
   unless $::settings::ca_server == $::settings::certname {
     fail('puppetdb_shared_cert::puppetdb only functions when compiled on the CA master. It cannot be used in a run against a compile master.')

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -1,8 +1,12 @@
 class puppetdb_shared_cert::puppetdb (
-  $certname = $puppetdb_shared_cert::certname,
+  $certname  = $puppetdb_shared_cert::certname,
+  $key_owner = 'root',
+  $key_group = '0',
 ) inherits puppetdb_shared_cert {
 
   validate_string($certname)
+  validate_string($key_owner)
+  validate_string($key_group)
 
   unless $::settings::ca_server == $::settings::certname {
     fail('puppetdb_shared_cert::puppetdb only functions when compiled on the CA master. It cannot be used in a run against a compile master.')
@@ -13,24 +17,24 @@ class puppetdb_shared_cert::puppetdb (
     content => file("/etc/puppetlabs/puppet/ssl/certs/${certname}.pem"),
     path    => "/etc/puppetlabs/puppet/ssl/certs/${certname}.pem",
     mode    => '0644',
-    owner   => 'pe-puppet',
-    group   => 'pe-puppet'
+    owner   => $key_owner,
+    group   => $key_group,
   }
   file { 'puppetdb-shared-publickey':
     ensure  => file,
     content => file("/etc/puppetlabs/puppet/ssl/private_keys/${certname}.pem"),
     path    => "/etc/puppetlabs/puppet/ssl/private_keys/${certname}.pem",
     mode    => '0644',
-    owner   => 'pe-puppet',
-    group   => 'pe-puppet'
+    owner   => $key_owner,
+    group   => $key_group,
   }
   file { 'puppetdb-shared-privatekey':
     ensure  => file,
     content => file("/etc/puppetlabs/puppet/ssl/public_keys/${certname}.pem"),
     path    => "/etc/puppetlabs/puppet/ssl/public_keys/${certname}.pem",
     mode    => '0644',
-    owner   => 'pe-puppet',
-    group   => 'pe-puppet'
+    owner   => $key_owner,
+    group   => $key_group,
   }
 
   Class['puppetdb_shared_cert::puppetdb'] -> Puppet_enterprise::Certs['pe-puppetdb']


### PR DESCRIPTION
This PR includes changes for clarity and PE 2015 support.
- Remove unused dns_alt_names parameter from the PuppetDB class.
- Parameterize and set the default key owner/group to root.
- Fix the swapped names for public/private puppetdb keys.

This change has been tested and is working with Puppet Enterprise 2015.2.2.
